### PR TITLE
高亮脚本的引入写错了

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 首先在head中引用chinese-article.css
 
-```
+```html
 <link rel="stylesheet" href="./public/css/chinese-article.css"/> 
 ```
 
 之后需要在文章的最外层div标签引入Class
 
-```
+```Html
 <div class="chinese-article">
   //文章内容
 </div>
@@ -20,10 +20,10 @@
 
 如果要显示代码样式，引入下列样式
 
-```
+```Html
 <link rel="stylesheet" href="./public/css/github-gist.css"/>
-<script href="./public/js/highlight.pack.js"/>
-<script>hljs.initHighlightingOnLoad();<script>
+<script src="./public/js/highlight.pack.js"></script>
+<script>hljs.initHighlightingOnLoad();</script>
 ```
 
 ## 编译方式
@@ -31,12 +31,12 @@
 如果你想fork并自定义项目，需要重新编译并生成新的 chinese-article.css 文件。
 
 确保全局安装了gulp
-```
+```Sh
 $ npm install -g gulp
 ```
 
 执行项目
-```
+```Sh
 $ npm isntall
 $ gulp
 ```


### PR DESCRIPTION
<script src="..."></script>这个小小的笔下误，对于那些直接复制粘贴的用户来说是个致命伤。
网页加载完会发现找不到 hljs 所以我更正了一下。